### PR TITLE
More passive-aggressive button labelling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ _site/
 .jekyll-metadata
 
 /.idea
+
+# branch notes
+NOTE

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -107,7 +107,7 @@ layout: compress
                         <button type="submit" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Will need sources!">Submit a new promise</button>
                     </form>
 			<form class="navbar-form navbar-right" action="https://goo.gl/forms/ceeFulWLxQOO2Wbz2" method="get" target="_blank">
-				<button type="submit" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title=":getout:">Contest the status of a promise</button>
+				<button type="submit" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title=":getout:">Document the status of a promise</button>
 			</form>
                     <ul class="nav navbar-nav navbar-right">
                         <li><a href="/about">About Us</a></li>


### PR DESCRIPTION
### Description of your *pull request*, and other information
More neutral language.
---

## Please follow (and edit) the guide below to expedite the pull request process.

- You will be asked a few questions:
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your issue will actually look like

---

### Make sure you are using the *latest* version: pull latest commits before reporting any issues.
- [ x] I've **verified** and **I assure** that I'm looking at the latest version of StarCitizen Tracker.

### Before submitting a *Pull Request* make sure you have:
- [ x] At least skimmed through [README](https://github.com/StarCitizenTracker/startcitizentracker.github.io/blob/master/README.md) and **most notably** the [To Do List](https://github.com/StarCitizenTracker/startcitizentracker.github.io#to-do-list) and [CONTRIBUTING.md](https://github.com/StarCitizenTracker/startcitizentracker.github.io/blob/master/CONTRIBUTING.md) pages.
- [x ] [Searched](https://github.com/StarCitizenTracker/startcitizentracker.github.io/pulls?utf8=%E2%9C%93&q=) through previous Pull Requests for similar issues including closed ones or just looking at the promises template

---

### Updating Policies and Promises through Pull Requests

There are three variables that need to be modified when a promise gets updated, namely `status`, `update`, and `citations`, through `data.yaml`.

`status` has **five** options:
 
- `Not started` = Default status. Nothing of significance has been talked about the promise.
- `In progress` = Promise is in progress, backed up with news articles and/ or government documents.
- `Broken` = Promise is __fully__ broken, backed up with news articles and/ or government documents.
- `Achieved` = Promise has been __fully__ completed, backed up with news articles and/ or government documents.
- `Compromised` = Promise has been __partially__ completed, backed up with news articles and/ or developer documents.

Where did you find out about the promise getting updated? These news articles should be added into the `citations` section. All you need to do is plug the news source into one of the provided spaces between the single quotes. The more the better, so please keep on adding news sources. We use this as a Wikipedia-style and [In-Text Citations](http://guides.lib.uw.edu/c.php?g=99161&p=642357). Please note that [archive.org](https://archive.org/) urls are preferred as these cannot be changed once captured. 

Note: Please try to keep the articles bias free, since we are not trying to lean any way. Public statements are the best option.

Please test after setting up to see if the promise got updated. Use the search function to check if the color got applied.
Setup instructions in [Read Me](https://github.com/StarCitizenTracker/startcitizentracker.github.io/blob/master/README.md).

After you're done with all of this you're ready to go! Send over the Pull Request and we will get back to you in one business day, if not sooner.

Thank you for your immense contribution, you're helping improve StarCitizenTracker everyday.
